### PR TITLE
[UPDATE] Update Node version dependency on setup doc

### DIFF
--- a/pages/setup.mdx
+++ b/pages/setup.mdx
@@ -3,7 +3,7 @@
 ## Requirements
 
 - NPM installed
-- Node installed (Version 14.15 or higher)
+- Node installed (Version 18 or higher)
 
 ## Config
 


### PR DESCRIPTION
After seeing different users report with the latest ThunderHub version that the compilation depends on Node 18 instead of the existing v14.15 on ThunderHub docs, I suggest the change with this PR

![photo_2023-11-28_12-58-50](https://github.com/apotdevin/thunderhub-docs/assets/89636253/af0f5557-f54d-48ec-9f93-a5167b8d3a5b)
![photo_2023-11-28_12-58-19](https://github.com/apotdevin/thunderhub-docs/assets/89636253/d2c42e52-88f8-4b95-9140-62e08b070b6f)

more context: 
https://t.me/thunderhub/13697
https://t.me/thunderhub/13706