### PR TITLE
chore: update docs as per thunderhub 0.15.0+

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -15,7 +15,7 @@ ThunderHub is integrated into several popular node platforms:
 - **[BTCPay Server](https://apotdevin.com/blog/thunderhub-btcpay)** — Included as part of the BTCPay Server deployment stack.
 - **[Raspiblitz](https://gist.github.com/openoms/8ba963915c786ce01892f2c9fa2707bc)** — Available as an optional service on Raspiblitz nodes.
 - **[myNode](https://mynodebtc.com/)** — Bundled with the myNode software suite.
-- **[Voltage](https://voltage.cloud/)** — Available on Voltage's hosted Lightning node platform.
+- **[Voltage](https://docs.voltage.cloud/thunderhub-guide)** — Available on Voltage's hosted Lightning node platform.
 - **[Umbrel](https://getumbrel.com/)** — Installable from the Umbrel App Store.
 
 ## Tech Stack
@@ -87,6 +87,6 @@ ThunderHub is a full-stack TypeScript application with a NestJS backend serving 
 
 ### Deployment
 
-- Docker images available on [Docker Hub](https://hub.docker.com/repository/docker/apotdevin/thunderhub).
+- Docker images available on [Docker Hub](https://hub.docker.com/r/apotdevin/thunderhub).
 - Reverse proxy support with configurable base path.
 - Tor proxy support for outbound requests.

--- a/content/installation.mdx
+++ b/content/installation.mdx
@@ -4,8 +4,13 @@ import { Callout, Tabs } from 'nextra/components';
 
 ## Requirements
 
-- **Node.js** version 18 or higher
-- **npm**
+- **[Node.js](https://nodejs.org/en)** version **24 or higher**
+- **[npm](https://www.npmjs.com/)**
+
+<Callout type="warning">
+  **ThunderHub [v0.15.0+](https://github.com/apotdevin/thunderhub/releases)
+  requires Node.js 24+.**
+</Callout>
 
 ## From Source
 
@@ -19,7 +24,8 @@ npm run build
 npm start
 ```
 
-The application starts on port `3000` by default. Open `http://localhost:3000` in your browser.
+The application starts on port `3000` by default. Open `http://localhost:3000`
+in your browser.
 
 To use a different port, set the `PORT` environment variable:
 
@@ -27,7 +33,8 @@ To use a different port, set the `PORT` environment variable:
 PORT=4000 npm start
 ```
 
-For production deployments, you can reduce disk usage by pruning development dependencies after the build:
+For production deployments, you can reduce disk usage by pruning development
+dependencies after the build:
 
 ```bash copy
 npm prune --production
@@ -46,7 +53,22 @@ Run all commands from inside the `thunderhub` directory.
 
 ## Docker
 
-Docker images are published to [Docker Hub](https://hub.docker.com/repository/docker/apotdevin/thunderhub).
+Docker images are published to
+[Docker Hub](https://hub.docker.com/r/apotdevin/thunderhub).
+Images are available for **`linux/amd64`** and **`linux/arm64`** platforms.
+
+<Callout type="warning">
+  Support for `linux/arm/v7` (32-bit ARM) was **dropped in v0.15.0**. If you
+  were running ThunderHub on a 32-bit ARM device, you will need to upgrade your
+  hardware or use a different deployment method.
+</Callout>
+
+```bash copy
+docker pull apotdevin/thunderhub:v0.15.5
+docker run --rm -it -p 3000:3000 apotdevin/thunderhub:v0.15.5
+```
+
+Or use `latest` to always pull the most recent release:
 
 ```bash copy
 docker pull apotdevin/thunderhub:latest
@@ -54,6 +76,11 @@ docker run --rm -it -p 3000:3000 apotdevin/thunderhub:latest
 ```
 
 Open `http://localhost:3000` to access ThunderHub.
+
+<Callout type="info">
+  The Docker image runs as a **non-root user** since v0.15.0. If you mount
+  volumes or config files, ensure the files are readable by a non-root user.
+</Callout>
 
 <Callout type="info">
   See the [Configuration](/setup) page for details on connecting ThunderHub to
@@ -67,3 +94,7 @@ To run ThunderHub in development mode with hot reloading:
 ```bash copy
 npm run dev
 ```
+
+## Breaking Changes in v0.15.0
+
+For a full list of removed features and architectural updates, please read the [v0.15.0 release notes](https://github.com/apotdevin/thunderhub/releases/tag/v0.15.0).


### PR DESCRIPTION
- update minimum nodejs version to 24+ now from 18+ earlier
- point to the exact voltage thunderhub guide
- update dockerhub links to https://hub.docker.com/r/apotdevin/thunderhub